### PR TITLE
Update snips_sql.py

### DIFF
--- a/sql_helpers/snips_sql.py
+++ b/sql_helpers/snips_sql.py
@@ -1,10 +1,10 @@
-from sqlalchemy import Column, UnicodeText, LargeBinary, Numeric
+from sqlalchemy import Column, UnicodeText, LargeBinary, Numeric, Unicode
 from sql_helpers import SESSION, BASE
 
 
 class Snips(BASE):
     __tablename__ = "snips"
-    snip = Column(UnicodeText, primary_key=True)
+    snip = Column(Unicode(255), primary_key=True)
     reply = Column(UnicodeText)
     snip_type = Column(Numeric)
     media_id = Column(UnicodeText)


### PR DESCRIPTION
Fixing the sqlalchemy.exc.OperationalError: (_mysql_exceptions.OperationalError) (1170, "BLOB/TEXT column 'snip' used in key specification without a key length") error