### PR TITLE
Update blacklist_sql.py

### DIFF
--- a/sql_helpers/blacklist_sql.py
+++ b/sql_helpers/blacklist_sql.py
@@ -1,6 +1,6 @@
 import threading
 
-from sqlalchemy import func, distinct, Column, String, UnicodeText
+from sqlalchemy import func, distinct, Column, String, UnicodeText, Unicode
 
 from sql_helpers import SESSION, BASE
 
@@ -8,7 +8,7 @@ from sql_helpers import SESSION, BASE
 class BlackListFilters(BASE):
     __tablename__ = "blacklist"
     chat_id = Column(String(14), primary_key=True)
-    trigger = Column(UnicodeText, primary_key=True, nullable=False)
+    trigger = Column(Unicode(255), primary_key=True, nullable=False)
 
     def __init__(self, chat_id, trigger):
         self.chat_id = str(chat_id)  # ensure string


### PR DESCRIPTION
Fixing the sqlalchemy.exc.OperationalError: (_mysql_exceptions.OperationalError) (1170, "BLOB/TEXT column 'blacklist' used in key specification without a key length") error